### PR TITLE
Replace pricing test with direct path to resource

### DIFF
--- a/test/otm_website_tests/pricing_test.clj
+++ b/test/otm_website_tests/pricing_test.clj
@@ -14,12 +14,7 @@
       (resp :status) => 302
       (get-in resp [:headers :location]) => "/pricing/"))
 
-  (fact "it returns a response from S3 if trailing slash on /preview exists"
-    (let [resp (head "/pricing/preview/")]
+  (fact "it returns a response from S3 if module.html exists"
+    (let [resp (head "/pricing/module.html")]
       (resp :status) => 200
-      (s3-response? resp) => true))
-
-  (fact "it returns a redirect if trailing slash on /preview is missing"
-    (let [resp (head "/pricing/preview")]
-      (resp :status) => 302
-      (get-in resp [:headers :location]) => "/pricing/preview/")))
+      (s3-response? resp) => true)))


### PR DESCRIPTION
Modular pricing is out of preview, so now the resource we want to test is `/pricing/module.html`.

Aims to resolve #2.
