### PR TITLE
Fix css tests when running against deployed app

### DIFF
--- a/test/otm_website_tests/css_test.clj
+++ b/test/otm_website_tests/css_test.clj
@@ -24,7 +24,12 @@
       (resp :status) => 200
       (s3-response? resp) => true))
 
-  (fact "it returns a response from the application if path begins with /css"
+  (fact "it returns a redirect from the application if path without a trailing slash begins with /css"
     (let [resp (head "/cssmap")]
+      (resp :status) => 301
+      (s3-response? resp) => false))
+
+  (fact "it returns a response from the application if path begins with /css"
+    (let [resp (head "/cssmap/")]
       (resp :status) => 404
       (s3-response? resp) => false)))


### PR DESCRIPTION
It is correct to assert that a request for /cssmap is passed to the application server and not proxied to S3, but I needed to fixup the tests to account for the 301 redirect returned from the application if the path does not end in a trailing slash.
